### PR TITLE
排除文件夹

### DIFF
--- a/src/concat.js
+++ b/src/concat.js
@@ -25,7 +25,7 @@ var Q = require("q");
  * * separator: 合并文件的分隔，默认;
  * @constructor
  */
-var Concat = function(options) {
+var Concat = function (options) {
     var self = this;
     self.options = {};
     Base.call(self, options);
@@ -36,7 +36,7 @@ var Concat = function(options) {
 };
 util.inherits(Concat, Base);
 
-Concat.prototype.execute = function(inputFile) {
+Concat.prototype.execute = function (inputFile) {
     var self = this;
     var deferred = Q.defer();
     var content = inputFile.content;
@@ -48,13 +48,12 @@ Concat.prototype.execute = function(inputFile) {
     var metaAst = null;
     if (self.options.useCache && _.has(self.astCache, source) &&
         self.astCache[source].ast
-        ) {
+    ) {
         ast = self.astCache[source].ast;
-    }
-    else {
+    } else {
         ast = cmdParser.getAst(content);
         if (!ast) {
-            process.nextTick(function() {
+            process.nextTick(function () {
                 deferred.reject({
                     message: Handlebars.compile("parse {{{source}}} failed")({
                         source: source
@@ -65,7 +64,7 @@ Concat.prototype.execute = function(inputFile) {
             return deferred.promise;
         }
         if (ast.error === true) {
-            process.nextTick(function() {
+            process.nextTick(function () {
                 deferred.reject({
                     message: Handlebars.compile("parse {{{source}}} ast failed: {{{line}}},{{{col}}}")({
                         source: source,
@@ -81,10 +80,9 @@ Concat.prototype.execute = function(inputFile) {
 
     if (self.options.useCache && _.has(self.astCache, source) &&
         self.astCache[source].metaAst
-        ) {
+    ) {
         metaAst = self.astCache[source].metaAst;
-    }
-    else {
+    } else {
         metaAst = cmdParser.parseFirst(ast);
         if (metaAst && self.options.useCache) {
             self.astCache[source] = {
@@ -95,7 +93,7 @@ Concat.prototype.execute = function(inputFile) {
     }
 
     if (!metaAst) {
-        process.nextTick(function() {
+        process.nextTick(function () {
             deferred.reject({
                 level: "warn",
                 message: Handlebars.compile("{{{source}}} is not CMD format")({
@@ -111,23 +109,20 @@ Concat.prototype.execute = function(inputFile) {
     var contents = [];
     if (self.options.useCache && self.dependenciesCache.hasOwnProperty(source)) {
         contents = self.dependenciesCache[source];
-    }
-    else {
+    } else {
         contents = [content];
-        _.each(dependencies, function(dependency) {
+        _.each(dependencies, function (dependency) {
             if (_.isFunction(self.options.idExtractor)) {
                 dependency = self.options.idExtractor(dependency);
             }
             var dependencyContent = null;
             if (_.has(self.idCache, dependency)) {
                 dependencyContent = self.readContentFromCache(dependency);
-            }
-            else if (dependency.indexOf("../") === 0 || dependency.indexOf("./") === 0) {
+            } else if (dependency.indexOf("../") === 0 || dependency.indexOf("./") === 0) {
                 dependencyContent = self.readContentForRelativePath(dependency,
                     path.dirname(source)
                 );
-            }
-            else {
+            } else {
                 dependencyContent = self.readContentFromLocal(dependency);
             }
             if (!dependencyContent) {
@@ -141,23 +136,27 @@ Concat.prototype.execute = function(inputFile) {
         // fix 佛山发现的依赖库被合并了两次的bug 2014-07-16
         self.idCache[metaAst.id] = content;
     }
-    contents = _.map(contents, function(content) {
-        return StringUtils.rstrip(content, {source: ";"});
+    contents = _.map(contents, function (content) {
+        return StringUtils.rstrip(content, {
+            source: ";"
+        });
     });
     contents = contents.join((self.options.separator || ";") + "\n");
-    contents = StringUtils.rstrip(contents, {source: ";"}) + (self.options.separator || ";");
-    process.nextTick(function() {
+    contents = StringUtils.rstrip(contents, {
+        source: ";"
+    }) + (self.options.separator || ";");
+    process.nextTick(function () {
         deferred.resolve(contents);
     });
     return deferred.promise;
 };
 
-Concat.prototype.readContentFromCache = function(id) {
+Concat.prototype.readContentFromCache = function (id) {
     var self = this;
     return self.idCache[id];
 };
 
-Concat.prototype.readContentForRelativePath = function(id, dirName) {
+Concat.prototype.readContentForRelativePath = function (id, dirName) {
     var self = this;
     var newPath = path.normalize(path.join(dirName, id));
     if (!/\.js$/.test(newPath)) {
@@ -180,17 +179,20 @@ Concat.prototype.readContentForRelativePath = function(id, dirName) {
     return content;
 };
 
-Concat.prototype.readContentFromLocal = function(id) {
+Concat.prototype.readContentFromLocal = function (id) {
     var self = this;
     var file = null;
-    _.some(self.options.paths, function(p) {
+    _.some(self.options.paths, function (p) {
         var newFile = path.join(p, id);
         if (!/\.js$/.test(newFile)) {
             newFile += ".js";
         }
         if (fs.existsSync(newFile)) {
-            file = newFile;
-            return true;
+            var stat = fs.statSync(newFile);
+            if (stat.isFile()) {
+                file = newFile;
+                return true;
+            }
         }
         return false;
     });
@@ -202,10 +204,9 @@ Concat.prototype.readContentFromLocal = function(id) {
     var metaAst = null;
     if (self.options.useCache && self.astCache.hasOwnProperty(file) &&
         self.astCache[file].metaAst
-        ) {
+    ) {
         metaAst = self.astCache[file].metaAst;
-    }
-    else {
+    } else {
         var cmdParser = new CmdParser();
         var ast = cmdParser.getAst(content);
         if (!ast || ast.error) {

--- a/src/concat.js
+++ b/src/concat.js
@@ -25,7 +25,7 @@ var Q = require("q");
  * * separator: 合并文件的分隔，默认;
  * @constructor
  */
-var Concat = function (options) {
+var Concat = function(options) {
     var self = this;
     self.options = {};
     Base.call(self, options);
@@ -36,7 +36,7 @@ var Concat = function (options) {
 };
 util.inherits(Concat, Base);
 
-Concat.prototype.execute = function (inputFile) {
+Concat.prototype.execute = function(inputFile) {
     var self = this;
     var deferred = Q.defer();
     var content = inputFile.content;
@@ -48,12 +48,13 @@ Concat.prototype.execute = function (inputFile) {
     var metaAst = null;
     if (self.options.useCache && _.has(self.astCache, source) &&
         self.astCache[source].ast
-    ) {
+        ) {
         ast = self.astCache[source].ast;
-    } else {
+    }
+    else {
         ast = cmdParser.getAst(content);
         if (!ast) {
-            process.nextTick(function () {
+            process.nextTick(function() {
                 deferred.reject({
                     message: Handlebars.compile("parse {{{source}}} failed")({
                         source: source
@@ -64,7 +65,7 @@ Concat.prototype.execute = function (inputFile) {
             return deferred.promise;
         }
         if (ast.error === true) {
-            process.nextTick(function () {
+            process.nextTick(function() {
                 deferred.reject({
                     message: Handlebars.compile("parse {{{source}}} ast failed: {{{line}}},{{{col}}}")({
                         source: source,
@@ -80,9 +81,10 @@ Concat.prototype.execute = function (inputFile) {
 
     if (self.options.useCache && _.has(self.astCache, source) &&
         self.astCache[source].metaAst
-    ) {
+        ) {
         metaAst = self.astCache[source].metaAst;
-    } else {
+    }
+    else {
         metaAst = cmdParser.parseFirst(ast);
         if (metaAst && self.options.useCache) {
             self.astCache[source] = {
@@ -93,7 +95,7 @@ Concat.prototype.execute = function (inputFile) {
     }
 
     if (!metaAst) {
-        process.nextTick(function () {
+        process.nextTick(function() {
             deferred.reject({
                 level: "warn",
                 message: Handlebars.compile("{{{source}}} is not CMD format")({
@@ -109,20 +111,23 @@ Concat.prototype.execute = function (inputFile) {
     var contents = [];
     if (self.options.useCache && self.dependenciesCache.hasOwnProperty(source)) {
         contents = self.dependenciesCache[source];
-    } else {
+    }
+    else {
         contents = [content];
-        _.each(dependencies, function (dependency) {
+        _.each(dependencies, function(dependency) {
             if (_.isFunction(self.options.idExtractor)) {
                 dependency = self.options.idExtractor(dependency);
             }
             var dependencyContent = null;
             if (_.has(self.idCache, dependency)) {
                 dependencyContent = self.readContentFromCache(dependency);
-            } else if (dependency.indexOf("../") === 0 || dependency.indexOf("./") === 0) {
+            }
+            else if (dependency.indexOf("../") === 0 || dependency.indexOf("./") === 0) {
                 dependencyContent = self.readContentForRelativePath(dependency,
                     path.dirname(source)
                 );
-            } else {
+            }
+            else {
                 dependencyContent = self.readContentFromLocal(dependency);
             }
             if (!dependencyContent) {
@@ -136,27 +141,23 @@ Concat.prototype.execute = function (inputFile) {
         // fix 佛山发现的依赖库被合并了两次的bug 2014-07-16
         self.idCache[metaAst.id] = content;
     }
-    contents = _.map(contents, function (content) {
-        return StringUtils.rstrip(content, {
-            source: ";"
-        });
+    contents = _.map(contents, function(content) {
+        return StringUtils.rstrip(content, {source: ";"});
     });
     contents = contents.join((self.options.separator || ";") + "\n");
-    contents = StringUtils.rstrip(contents, {
-        source: ";"
-    }) + (self.options.separator || ";");
-    process.nextTick(function () {
+    contents = StringUtils.rstrip(contents, {source: ";"}) + (self.options.separator || ";");
+    process.nextTick(function() {
         deferred.resolve(contents);
     });
     return deferred.promise;
 };
 
-Concat.prototype.readContentFromCache = function (id) {
+Concat.prototype.readContentFromCache = function(id) {
     var self = this;
     return self.idCache[id];
 };
 
-Concat.prototype.readContentForRelativePath = function (id, dirName) {
+Concat.prototype.readContentForRelativePath = function(id, dirName) {
     var self = this;
     var newPath = path.normalize(path.join(dirName, id));
     if (!/\.js$/.test(newPath)) {
@@ -179,10 +180,10 @@ Concat.prototype.readContentForRelativePath = function (id, dirName) {
     return content;
 };
 
-Concat.prototype.readContentFromLocal = function (id) {
+Concat.prototype.readContentFromLocal = function(id) {
     var self = this;
     var file = null;
-    _.some(self.options.paths, function (p) {
+    _.some(self.options.paths, function(p) {
         var newFile = path.join(p, id);
         if (!/\.js$/.test(newFile)) {
             newFile += ".js";
@@ -204,9 +205,10 @@ Concat.prototype.readContentFromLocal = function (id) {
     var metaAst = null;
     if (self.options.useCache && self.astCache.hasOwnProperty(file) &&
         self.astCache[file].metaAst
-    ) {
+        ) {
         metaAst = self.astCache[file].metaAst;
-    } else {
+    }
+    else {
         var cmdParser = new CmdParser();
         var ast = cmdParser.getAst(content);
         if (!ast || ast.error) {


### PR DESCRIPTION
我有一个共公的业务模块 `global/0.0.1/global`  我使用别名 `global` 在业务模块中引用。
在执行concat时，是不希望它被包含到这些业务模块中的。

我发现因为有global这个文件夹的存在，路径分析时一直会执行到`var parser = new Parser(transportConfig);`报错。

所以我认为在分析路径时需要检查一下当前路径是不是一个文件。